### PR TITLE
support local logging for test

### DIFF
--- a/log/local_logger.go
+++ b/log/local_logger.go
@@ -1,0 +1,23 @@
+package log
+
+import (
+	"log"
+
+	"cloud.google.com/go/logging"
+)
+
+type localLogger struct {
+	logger *log.Logger
+}
+
+func (l *localLogger) Log(e logging.Entry) {
+	l.logger.Printf("[%s] %v", e.Severity, e.Payload)
+}
+
+func (l *localLogger) Flush() error {
+	return nil
+}
+
+func (l *localLogger) StandardLogger(s logging.Severity) *log.Logger {
+	return l.logger
+}


### PR DESCRIPTION
ローカルでの利用時のみ標準のlog.Default()を渡せるようにしました。
（ローカルでテストする際、にloggingサーバへアクセスできないためログが出力できなかった）