### PR TITLE
remove go1.16 feature

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -33,7 +33,7 @@ type stdLogger interface {
 
 func init() {
 	if !metadata.OnGCE() {
-		std = &localLogger{logger: log.Default()}
+		std = &localLogger{logger: log.New(os.Stderr, "", log.LstdFlags)}
 		return
 	}
 


### PR DESCRIPTION
log.Defaultがgo1.16からだったので、いったん別のlogオブジェクトを渡すようにしました